### PR TITLE
CPM and GFSK tweaks and fixes.

### DIFF
--- a/grc/signal_exciter_cpm_hier.xml
+++ b/grc/signal_exciter_cpm_hier.xml
@@ -11,16 +11,19 @@ sig_params = signal_exciter.sig_params()
 sig_params.type                     = $mtype
 sig_params.sps                      = $sps
 #if $mtype() in ('signal_exciter.FSK', 'signal_exciter.CPM', 'signal_exciter.GFSK')
-sig_params.cpm_params.fm_sense      = $sense
+sig_params.order                    = $order
+sig_params.mod_idx                  = $midx
+#else
+sig_params.order                    = 2
 #end if
 #if $mtype() in ('signal_exciter.CPM', 'signal_exciter.GMSK', 'signal_exciter.GFSK')
-sig_params.cpm_params.L             = $L
-sig_params.cpm_params.beta          = $beta
+sig_params.L                        = $L
+sig_params.beta                     = $beta
 #end if
 #if $mtype() in ('signal_exciter.CPM')
-sig_params.cpm_params.phase_type    = $ptype
+sig_params.phase_type               = $ptype
 #end if
-self.$id = signal_exciter.cpm_hier(sig_params, $seed)
+self.$id = signal_exciter.cpm_hier(sig_params, $gray)
 </make>
 
 
@@ -76,11 +79,45 @@ self.$id = signal_exciter.cpm_hier(sig_params, $seed)
     </option>
     <option>
       <name>Gaussian</name>
-      <key>analog.cpm.Gaussian</key>
+      <key>analog.cpm.GAUSSIAN</key>
     </option>
     <option>
       <name>Tamed FM</name>
       <key>analog.cpm.TFM</key>
+    </option>
+  </param>
+  <param>
+    <name>Modulation Order</name>
+    <key>order</key>
+    <value>2</value>
+    <type>int</type>
+    <hide>
+#if $mtype() in ('signal_exciter.CPM','signal_exciter.GFSK','signal_exciter.FSK')
+  none
+#else
+  all
+#end if
+    </hide>
+  </param>
+  <param>
+    <name>Gray Coding</name>
+    <key>gray</key>
+    <value>True</value>
+    <type>enum</type>
+    <hide>
+#if $mtype() in ('signal_exciter.CPM','signal_exciter.GFSK','signal_exciter.FSK')
+  none
+#else
+  all
+#end if
+    </hide>
+    <option>
+      <name>Yes</name>
+      <key>True</key>
+    </option>
+    <option>
+      <name>No</name>
+      <key>False</key>
     </option>
   </param>
   <param>
@@ -90,9 +127,9 @@ self.$id = signal_exciter.cpm_hier(sig_params, $seed)
     <type>int</type>
   </param>
   <param>
-    <name>Sensitivity</name>
-    <key>sense</key>
-    <value>pi/2.</value>
+    <name>Modulation Index</name>
+    <key>midx</key>
+    <value>0.5</value>
     <type>real</type>
     <hide>
 #if $mtype() in ('signal_exciter.FSK', 'signal_exciter.CPM', 'signal_exciter.GFSK')
@@ -128,16 +165,17 @@ self.$id = signal_exciter.cpm_hier(sig_params, $seed)
 #end if
     </hide>
   </param>
-  <param>
-    <name>Seed</name>
-    <key>seed</key>
-    <value>-1</value>
-    <type>int</type>
-  </param>
 
-
+  <sink>
+    <name>in</name>
+    <type>byte</type>
+  </sink>
   <source>
     <name>out</name>
     <type>complex</type>
   </source>
+
+  <doc>
+    For GFSK -> Sensitivity = PI*(Modulation Index)
+  </doc>
 </block>

--- a/include/signal_exciter/cpm_hier.h
+++ b/include/signal_exciter/cpm_hier.h
@@ -47,7 +47,7 @@ namespace gr {
        * class. signal_exciter::cpm_hier::make is the public interface for
        * creating new instances.
        */
-      static sptr make(sig_params sig, int seed=-1);
+      static sptr make(sig_params sig, bool gray=false);
     };
 
   } // namespace signal_exciter

--- a/include/signal_exciter/random_signal_config.h
+++ b/include/signal_exciter/random_signal_config.h
@@ -48,15 +48,6 @@ namespace gr {
       GFSK    = 14
     };
 
-    struct SIGNAL_EXCITER_API cpm_struct
-    {
-     public:
-      unsigned L;                           // number of symbols to overlap
-      int phase_type; // phase type
-      float beta;                           // beta for gaussian & spectral raised cosine
-      float fm_sense;                       // fm sensitivty -> pi*mod_idx for some
-    };
-
     struct SIGNAL_EXCITER_API sig_params
     {
      public:
@@ -104,9 +95,8 @@ namespace gr {
       unsigned L;                           // number of overlapping symbols in CPM mods
       float beta;                           // beta for gaussian & spectral raised cosine
       int phase_type;                       // gr::analog::cpm::cpm_type
-      cpm_struct cpm_params;                // where all the cpm type modulations will have their parameters stored
 
-       bool am_norm;                        // Enable the agc on the AM signals
+      bool am_norm;                        // Enable the agc on the AM signals
     };
 
   } // namespace signal_exciter

--- a/lib/cpm_hier_impl.cc
+++ b/lib/cpm_hier_impl.cc
@@ -34,64 +34,69 @@ namespace gr {
   namespace signal_exciter {
 
     cpm_hier::sptr
-    cpm_hier::make(sig_params sig, int seed)
+    cpm_hier::make(sig_params sig, bool gray)
     {
       return gnuradio::get_initial_sptr
-        (new cpm_hier_impl(sig, seed));
+        (new cpm_hier_impl(sig, gray));
     }
 
     /*
      * The private constructor
      */
-    cpm_hier_impl::cpm_hier_impl(sig_params sig, int seed)
+    cpm_hier_impl::cpm_hier_impl(sig_params sig, bool gray)
       : gr::hier_block2("cpm_hier",
-              gr::io_signature::make(0, 0, 0),
-              gr::io_signature::make(1, 1, sizeof(gr_complex)))
+              gr::io_signature::make(1, 1, sizeof(unsigned char)),
+              gr::io_signature::make(1, 1, sizeof(gr_complex))),
+        d_gray(gray)
     {
       //printf("CPM HIER STARTING.\n");
-      float syms[2] = {-1.,1.};
-      d_symbols = std::vector<float>(syms,syms+sizeof(syms)/sizeof(float));
+      d_order = sig.order;
+      int order = sig.order;
+      int new_order=0;
+      while(order>0){
+        order = order>>1;
+        if(!new_order) new_order = 1;
+        else new_order = new_order*2;
+      }
+      if((new_order != d_order) || (d_order == 0)){
+        if(new_order > 0) d_order = new_order;
+        else d_order = 2;
+      }
 
-      if(seed<0) d_seed = (time(NULL));
-      else d_seed = seed;
+      create_symbol_list();
 
-      d_src = gr::analog::random_uniform_source_b::make(0,256,d_seed);
-      d_upk = gr::blocks::packed_to_unpacked_bb::make(1,gr::GR_MSB_FIRST);
+      //d_src = gr::analog::random_uniform_source_b::make(0,256,d_seed);
+      //d_upk = gr::blocks::packed_to_unpacked_bb::make(1,gr::GR_MSB_FIRST);
       d_sym = gr::digital::chunks_to_symbols_bf::make(d_symbols,1);
 
       switch(sig.type){
         case GFSK :{
           d_phase_type = gr::analog::cpm::GAUSSIAN;
-          d_sym_overlap = sig.cpm_params.L;
-          d_sensitivity = sig.cpm_params.fm_sense;
-          d_beta = sig.cpm_params.beta;
+          d_sym_overlap = sig.L;
+          d_mod_idx = sig.mod_idx;
+          d_beta = sig.beta;
 
           std::vector<float> gt = gr::filter::firdes::gaussian(1,sig.sps,d_beta,d_sym_overlap*sig.sps);
+
           std::vector<float> rt(sig.sps,1.);
           d_taps = std::vector<float>(gt.size()+rt.size()-1);
           for(size_t idx = 0; idx < d_taps.size(); idx++){
             size_t count = std::min(std::min(idx,rt.size()),gt.size());
 
             float summer = 0.;
-            for(size_t dp = 0; dp <= count; dp++){
+            for(size_t dp = 0; dp < count; dp++){
               if(idx-dp < gt.size())
                 summer += gt[idx-dp]*rt[dp];
             }
             d_taps[idx] = summer;
           }
-          //d_taps = gr::filter::firdes::gaussian(1,sig.sps,d_beta,d_sym_overlap*sig.sps);
-          //printf("(%1.14e",d_taps[0]);
-          //for(size_t idx = 1; idx < d_taps.size(); idx++){
-          //  printf(", %1.14e",d_taps[idx]);
-          //}
-          //printf(")\n");
           break;
         }
         case CPM :{
-          d_phase_type = gr::analog::cpm::cpm_type(sig.cpm_params.phase_type);
-          d_sym_overlap = sig.cpm_params.L;
-          d_sensitivity = sig.cpm_params.fm_sense;
-          d_beta = sig.cpm_params.beta;
+          d_phase_type = gr::analog::cpm::cpm_type(sig.phase_type);
+          d_sym_overlap = sig.L;
+          d_mod_idx = sig.mod_idx;
+          d_beta = sig.beta;
 
           d_taps = gr::analog::cpm::phase_response(d_phase_type, sig.sps, d_sym_overlap, d_beta);
           break;
@@ -99,7 +104,7 @@ namespace gr {
         case MSK :{
           d_phase_type = gr::analog::cpm::LREC;
           d_sym_overlap = 1;
-          d_sensitivity = 0.5;
+          d_mod_idx = 0.5;
           d_beta = 0;
 
           d_taps = gr::analog::cpm::phase_response(d_phase_type, sig.sps, d_sym_overlap, d_beta);
@@ -107,9 +112,9 @@ namespace gr {
         }
         case GMSK :{
           d_phase_type = gr::analog::cpm::GAUSSIAN;
-          d_sym_overlap = sig.cpm_params.L;
-          d_sensitivity = M_PI/2.;
-          d_beta = sig.cpm_params.beta;
+          d_sym_overlap = sig.L;
+          d_mod_idx = 0.5;
+          d_beta = sig.beta;
 
           d_taps = gr::analog::cpm::phase_response(d_phase_type, sig.sps, d_sym_overlap, d_beta);
           break;
@@ -117,16 +122,10 @@ namespace gr {
         case FSK :{
           d_phase_type = gr::analog::cpm::LREC;
           d_sym_overlap = 1;
-          d_sensitivity = sig.cpm_params.fm_sense;
+          d_mod_idx = sig.mod_idx;
           d_beta = 0;
 
-          //d_taps = std::vector<float>(sig.sps,1.);
           d_taps = gr::analog::cpm::phase_response(d_phase_type, sig.sps, d_sym_overlap, d_beta);
-          //printf("(%1.14e",d_taps[0]);
-          //for(size_t idx = 1; idx < d_taps.size(); idx++){
-          //  printf(", %1.14e",d_taps[idx]);
-          //}
-          //printf(")\n");
           break;
         }
         default :{
@@ -134,13 +133,21 @@ namespace gr {
           break;
         }
       }
+
+      //printf("sps = %d;taps = (%1.14e",sig.sps,d_taps[0]);
+      //for(size_t idx = 1; idx < d_taps.size(); idx++){
+      //  printf(", %1.14e",d_taps[idx]);
+      //}
+      //printf(")\n");
+
       d_fir = gr::filter::interp_fir_filter_fff::make(sig.sps, d_taps);
-      d_fm = gr::analog::frequency_modulator_fc::make(d_sensitivity);
+      d_fm = gr::analog::frequency_modulator_fc::make(M_PI * d_mod_idx);
 
 
-      connect(d_src, 0, d_upk, 0);
-      connect(d_upk, 0, d_sym, 0);
+      //connect(d_src, 0, d_upk, 0);
+      //connect(d_upk, 0, d_sym, 0);
       //connect(d_sym, 0,self(), 0);
+      connect(self(), 0, d_sym, 0);
       connect(d_sym, 0, d_fir, 0);
       connect(d_fir, 0, d_fm , 0);
       connect(d_fm , 0, self(), 0);
@@ -152,6 +159,52 @@ namespace gr {
      */
     cpm_hier_impl::~cpm_hier_impl()
     {
+    }
+
+    void
+    cpm_hier_impl::create_symbol_list()
+    {
+      //gray coding pulled from gr-digital/python/digital/utils/gray_code.py
+
+      //printf("Making symbols.\n");
+      d_symbols = std::vector<float>(d_order,0.);
+      if(d_gray){
+        std::vector<int> sym_base(2,0);
+        sym_base[1] = 1;
+        //printf("sym_base = [%d,%d];\n",sym_base[0],sym_base[1]);
+        int lp2 = 2;
+        int np2 = 4;
+        int ind = 2;
+        int result;
+        while(sym_base.size() < d_order){
+          if(ind == lp2)
+            result = ind + ind/2;
+          else
+            result = sym_base[2*lp2-1-ind] + lp2;
+          sym_base.push_back(result);
+          ind++;
+          if(ind == np2){
+            lp2 = ind;
+            np2 = ind*2;
+          }
+        }
+        for(int idx = 0; idx < d_order; idx++){
+        //  printf("%d ", sym_base[idx]*2-int(d_order)+1);
+          d_symbols[idx] = float(sym_base[idx]*2-int(d_order)+1);
+        }
+        //printf("\n");
+      }
+      else{
+        for(int idx = 0; idx < d_order; idx++){
+          d_symbols[idx] = float(idx*2-int(d_order)+1);
+        }
+      }
+
+      //printf("Symbols: [%1.0f",d_symbols[0]);
+      //for(int idx = 1; idx < d_order; idx++){
+      //  printf(", %1.0f", d_symbols[idx]);
+      //}
+      //printf("]\n");
     }
 
 

--- a/lib/cpm_hier_impl.h
+++ b/lib/cpm_hier_impl.h
@@ -40,10 +40,13 @@ namespace gr {
     {
      private:
       gr::analog::cpm::cpm_type d_phase_type;
+      size_t d_order;
       size_t d_sym_overlap;
-      double d_sensitivity;
+      double d_mod_idx;
       double d_beta;
-      size_t d_seed;
+      //size_t d_seed;
+      bool d_gray;
+      bool d_conv;
 
       std::vector<float> d_symbols;
       std::vector<float> d_taps;
@@ -54,8 +57,10 @@ namespace gr {
       gr::blocks::packed_to_unpacked_bb::sptr d_upk;
       gr::digital::chunks_to_symbols_bf::sptr d_sym;
 
+      void create_symbol_list();
+
      public:
-      cpm_hier_impl(sig_params sig, int seed);
+      cpm_hier_impl(sig_params sig, bool gray=false);
       ~cpm_hier_impl();
 
     };


### PR DESCRIPTION
Left a few indexing bugs in the GFSK phase shaping taps.
Switch the random signal to use the GFSK_mod phase shaping: firdes::gaussian instead of cpm::gaussian.

CPM heir block now is functioning as a pass through and operates on integer inputs.
