### PR TITLE
Changed OFDM functionality.

### DIFF
--- a/grc/signal_exciter_random_signal.xml
+++ b/grc/signal_exciter_random_signal.xml
@@ -15,7 +15,7 @@ sig_params.mod              = $mod
 sig_params.order            = $order
 sig_params.offset           = $offset
 #end if
-#if $mtype() in ('signal_exciter.PSK', 'signal_exciter.QAM', 'signal_exciter.PAM', 'signal_exciter.ASK',  'signal_exciter.OFDM')
+#if $mtype() in ('signal_exciter.PSK', 'signal_exciter.QAM', 'signal_exciter.PAM', 'signal_exciter.ASK')
 sig_params.sps              = $sps
 sig_params.pulse_len        = $pulse_len
 
@@ -69,6 +69,29 @@ for ii in range(#end raw $pilot_count#raw):#end raw
   $plid#raw [ii] = #end raw $temp#raw [ii]
 #end raw
 sig_params.pilot_locations  = $plid
+sig_params.samp_overlap     = $samp_overlap
+
+#set $tpid = '_%s_taper'%$id
+#set $temp = '_%s_temp'%$id
+$tpid = signal_exciter.FloatVector(sig_params.samp_overlap)
+$temp = $taper
+#raw
+for ii in range(#end raw $samp_overlap#raw):#end raw
+  $tpid#raw [ii] = #end raw $temp#raw [ii]
+#end raw
+sig_params.taper            = $tpid
+sig_params.sps              = $interp
+sig_params.pulse_len        = $interp_len
+
+#set $psid = '_%s_pulse_shape'%$id
+#set $temp = '_%s_temp'%$id
+$psid = signal_exciter.FloatVector(sig_params.pulse_len)
+$temp = $interp_taps
+#raw
+for ii in range(#end raw $interp_len#raw):#end raw
+  $psid#raw [ii] = #end raw $temp#raw [ii]
+#end raw
+sig_params.pulse_shape      = $psid
 
 sig_params.backoff          = $backoff
 sig_params.add_sync         = $add_sync
@@ -222,7 +245,7 @@ sig_params.pilot_locations  = pilot_loc_($id)-->
     <value>1</value>
     <type>int</type>
     <hide>
-#if $mtype() in ('signal_exciter.PSK', 'signal_exciter.QAM', 'signal_exciter.PAM', 'signal_exciter.ASK', 'signal_exciter.MSK', 'signal_exciter.GMSK', 'signal_exciter.FSK', 'signal_exciter.GFSK', 'signal_exciter.CPM', 'signal_exciter.OFDM')
+#if $mtype() in ('signal_exciter.PSK', 'signal_exciter.QAM', 'signal_exciter.PAM', 'signal_exciter.ASK', 'signal_exciter.MSK', 'signal_exciter.GMSK', 'signal_exciter.FSK', 'signal_exciter.GFSK', 'signal_exciter.CPM')
   none
 #else
   all
@@ -235,7 +258,7 @@ sig_params.pilot_locations  = pilot_loc_($id)-->
     <value>[1]</value>
     <type>float_vector</type>
     <hide>
-#if $mtype() in ('signal_exciter.PSK', 'signal_exciter.QAM', 'signal_exciter.PAM', 'signal_exciter.ASK',  'signal_exciter.OFDM')
+#if $mtype() in ('signal_exciter.PSK', 'signal_exciter.QAM', 'signal_exciter.PAM', 'signal_exciter.ASK')
   none
 #else
   all
@@ -248,7 +271,7 @@ sig_params.pilot_locations  = pilot_loc_($id)-->
     <value>1</value>
     <type>int</type>
     <hide>
-#if $mtype() in ('signal_exciter.PSK', 'signal_exciter.QAM', 'signal_exciter.PAM', 'signal_exciter.ASK',  'signal_exciter.OFDM')
+#if $mtype() in ('signal_exciter.PSK', 'signal_exciter.QAM', 'signal_exciter.PAM', 'signal_exciter.ASK')
   none
 #else
   all
@@ -558,6 +581,71 @@ sig_params.pilot_locations  = pilot_loc_($id)-->
       <name>Tamed FM</name>
       <key>cpm.TFM</key>
     </option>
+  </param>
+  <param>
+    <name>Interpolation</name>
+    <key>interp</key>
+    <value>1</value>
+    <type>int</type>
+    <hide>
+#if $mtype() in ('signal_exciter.OFDM')
+  none
+#else
+  all
+#end if
+    </hide>
+  </param>
+  <param>
+    <name>Interpolation Taps</name>
+    <key>interp_taps</key>
+    <value>[1]</value>
+    <type>float_vector</type>
+    <hide>
+#if $mtype() in ('signal_exciter.OFDM')
+  none
+#else
+  all
+#end if
+    </hide>
+  </param>
+  <param>
+    <name>Interpolation Tap Length</name>
+    <key>interp_len</key>
+    <value>1</value>
+    <type>int</type>
+    <hide>
+#if $mtype() in ('signal_exciter.OFDM')
+  none
+#else
+  all
+#end if
+    </hide>
+  </param>
+  <param>
+    <name>Taper</name>
+    <key>taper</key>
+    <value>[]</value>
+    <type>float_vector</type>
+    <hide>
+#if $mtype() in ('signal_exciter.OFDM')
+  none
+#else
+  all
+#end if
+    </hide>
+  </param>
+  <param>
+    <name>Sample Base Overlap</name>
+    <key>samp_overlap</key>
+    <value>0</value>
+    <type>int</type>
+    <hide>
+#if $mtype() in ('signal_exciter.OFDM')
+  none
+#else
+  all
+#end if
+    </hide>
   </param>
   <param>
     <name>Seed</name>

--- a/include/signal_exciter/random_signal_config.h
+++ b/include/signal_exciter/random_signal_config.h
@@ -96,7 +96,10 @@ namespace gr {
       float beta;                           // beta for gaussian & spectral raised cosine
       int phase_type;                       // gr::analog::cpm::cpm_type
 
-      bool am_norm;                        // Enable the agc on the AM signals
+      bool am_norm;                         // Enable the agc on the AM signals
+
+      std::vector<float> taper;             // OFDM Specific
+      size_t samp_overlap;                  // OFDM Specific
     };
 
   } // namespace signal_exciter

--- a/lib/random_signal_impl.cc
+++ b/lib/random_signal_impl.cc
@@ -80,7 +80,8 @@ namespace gr {
       else if(mod_type == OFDM){
         d_mod = new Signal_OFDM(d_params.fftsize,d_params.cp_len,d_params.active_carriers,d_params.syms_per_frame,
           d_params.pilot_per_frame, d_params.pilot_count, &d_params.pilot_locations[0], d_params.backoff,
-          d_params.mod, d_params.order,d_params.offset, seed, d_params.add_sync,&d_params.pulse_shape[0],d_params.pulse_len,int(d_params.sps));
+          d_params.mod, d_params.order,d_params.offset, seed, d_params.add_sync, &d_params.taper[0], d_params.samp_overlap,
+          &d_params.pulse_shape[0], d_params.pulse_len, int(d_params.sps));
       }
       else if(mod_type == CWMORSE){
         //printf("cpw = %d\nwpm = %0.0f\nbw = %u\nsr = %lf",sig.char_per_word,sig.words_per_minute,sig.base_word,(double(sig.words_per_minute*(sig.base_word ? 60 : 50))/60.));

--- a/lib/signal_ofdm.hpp
+++ b/lib/signal_ofdm.hpp
@@ -22,6 +22,7 @@ class Signal_OFDM : public Signal_Base
     size_t d_cp_len;
     size_t d_active;
     size_t d_spf;
+    size_t d_samp_overlap;
     bool d_ppf;
     size_t d_npilots;
     std::vector<size_t> d_active_list;
@@ -76,7 +77,8 @@ class Signal_OFDM : public Signal_Base
     size_t d_branch_offset;//starting branch in interp filter
     size_t d_samp_offset;//starting sample in frame
     size_t d_frame_offset;//starting frame in cache
-    std::vector<float> d_window;
+    std::vector<float> d_interp_taps;
+    std::vector<float> d_taper;
     std::vector< gr::filter::kernel::fir_filter_ccf* > d_firs;
     std::vector< std::vector<float> > d_taps;
     size_t d_hist;
@@ -105,7 +107,7 @@ class Signal_OFDM : public Signal_Base
     Signal_OFDM(size_t fftsize, size_t cp_len, size_t active_carriers, size_t syms_per_frame, 
                 bool pilot_per_frame, size_t pilot_count, size_t* pilot_locations, float backoff,
                 int mod_type, int mod_order, float mod_offset, int seed, bool add_sync=false,
-                float* window=NULL, size_t length=0, int interp=1,
+                float* symbol_taper=NULL, size_t sample_overlap=0, float* interp_taps=NULL, size_t tap_len=0, int interp=1,
                 bool enable=true, size_t buff_size=8192, size_t min_notify=512);
     ~Signal_OFDM();
 


### PR DESCRIPTION
Changed OFDM functionality.
No longer using the 'SPS,Pulse Shape,Pulse Shape len', now using a more clear 'interp,interp taps,tap len' for the interpolation of OFDM signal, and a 'taper, samp_overlap' for the windowing of OFDM symbols and overlapping them. Taper is assumed to be symmetric, therefore only the rise is needed, and len(taper) == samp_overlap. Taper is simply mapped backward for the falling portion of the OFDM symbol.