### PR TITLE
OFDM and random seed overhaul

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,15 +49,13 @@ if(UNIX AND EXISTS "/usr/lib64")
     list(APPEND BOOST_LIBRARYDIR "/usr/lib64") #fedora 64-bit fix
 endif(UNIX AND EXISTS "/usr/lib64")
 set(Boost_ADDITIONAL_VERSIONS
-    "1.35.0" "1.35" "1.36.0" "1.36" "1.37.0" "1.37" "1.38.0" "1.38" "1.39.0" "1.39"
-    "1.40.0" "1.40" "1.41.0" "1.41" "1.42.0" "1.42" "1.43.0" "1.43" "1.44.0" "1.44"
     "1.45.0" "1.45" "1.46.0" "1.46" "1.47.0" "1.47" "1.48.0" "1.48" "1.49.0" "1.49"
     "1.50.0" "1.50" "1.51.0" "1.51" "1.52.0" "1.52" "1.53.0" "1.53" "1.54.0" "1.54"
     "1.55.0" "1.55" "1.56.0" "1.56" "1.57.0" "1.57" "1.58.0" "1.58" "1.59.0" "1.59"
     "1.60.0" "1.60" "1.61.0" "1.61" "1.62.0" "1.62" "1.63.0" "1.63" "1.64.0" "1.64"
     "1.65.0" "1.65" "1.66.0" "1.66" "1.67.0" "1.67" "1.68.0" "1.68" "1.69.0" "1.69"
 )
-find_package(Boost "1.35" COMPONENTS filesystem system)
+find_package(Boost "1.45" COMPONENTS filesystem system random)
 
 if(NOT Boost_FOUND)
     message(FATAL_ERROR "Boost required to compile signal_exciter")

--- a/include/signal_exciter/gaussian_mixture.h
+++ b/include/signal_exciter/gaussian_mixture.h
@@ -26,6 +26,7 @@
 #include <time.h>
 #include <boost/random.hpp>
 #include <boost/random/normal_distribution.hpp>
+#include <boost/random/random_device.hpp>
 #include <stdio.h>
 #include <gnuradio/filter/fir_filter.h>
 
@@ -34,15 +35,16 @@ class Gaussian_Mixture
   private:
     int d_seed;
 
+    boost::random_device d_rd;
+    boost::mt19937 d_rng;
+
   public:
 
     void set_seed(int seed)
     {
       //printf("Setting the seed\n");
       d_seed = seed;
-      //if(d_seed<0) d_rng->seed(time(NULL));
-      //else d_rng->seed(d_seed);
-      if(d_seed<0) d_seed = time(NULL);
+      if(d_seed < 0) d_seed = d_rd();
       d_rng.seed(d_seed);
     }
 
@@ -65,7 +67,7 @@ class Gaussian_Mixture
 
     gr::filter::kernel::fir_filter_fff* d_fir;
 
-    boost::mt19937 d_rng;
+
     //boost::mt19937 *d_rng;
     //boost::normal_distribution<> d_dist1;
     //boost::normal_distribution<> d_dist2;

--- a/include/signal_exciter/signal_base.hpp
+++ b/include/signal_exciter/signal_base.hpp
@@ -12,6 +12,7 @@
 #include <signal_exciter/signal_threaded_buffer.h>
 #include <boost/thread/mutex.hpp>
 #include <gnuradio/random.h>
+#include <boost/random/random_device.hpp>
 
 
 typedef std::complex<float> complexf;
@@ -31,6 +32,7 @@ class Signal_Base
     virtual void auto_fill_signal() = 0;
 
   protected:
+    boost::random_device d_rd;
     gr::random *d_rng;
     //For thread safe create of fftw objects.
     static boost::mutex s_mutex_fftw;

--- a/lib/gmm_impl.h
+++ b/lib/gmm_impl.h
@@ -45,6 +45,7 @@ namespace gr {
       int work(int noutput_items,
          gr_vector_const_void_star &input_items,
          gr_vector_void_star &output_items);
+
     };
 
   } // namespace signal_exciter

--- a/lib/random_gate_impl.h
+++ b/lib/random_gate_impl.h
@@ -23,6 +23,7 @@
 
 #include <signal_exciter/random_gate.h>
 #include <gnuradio/random.h>
+#include <boost/random/random_device.hpp>
 
 namespace gr {
   namespace signal_exciter {
@@ -45,6 +46,7 @@ namespace gr {
       size_t d_cycle_count;
       size_t d_cycle_counter;
 
+      boost::random_device d_rd;
       gr::random* d_rng;
 
       size_t rand_on();
@@ -62,8 +64,7 @@ namespace gr {
       void set_seed(int seed)
       {
         d_seed = seed;
-        if(d_seed<0) d_seed = time(NULL);
-        //srand(d_seed);
+        if(d_seed < 0) d_seed = d_rd();
       }
     };
 

--- a/lib/signal_cpm.hpp
+++ b/lib/signal_cpm.hpp
@@ -70,8 +70,7 @@ class Signal_CPM : public Signal_Base
     void set_seed(int seed)
     {
       d_seed = seed;
-      if(d_seed < 0) d_seed = time(NULL);
-//      srand(d_seed);
+      if(d_seed < 0) d_seed = d_rd();
     }
 };
 #endif /* INCLUDED_SIGNAL_CPM_HPP */

--- a/lib/signal_cwmorse.hpp
+++ b/lib/signal_cwmorse.hpp
@@ -66,8 +66,7 @@ class Signal_CWMORSE : public Signal_Base
     void set_seed(int seed)
     {
       d_seed = seed;
-      if(d_seed < 0) d_seed = time(NULL);
-//      srand(d_seed);
+      if(d_seed < 0) d_seed = d_rd();
     }
 
 };

--- a/lib/signal_dsb.hpp
+++ b/lib/signal_dsb.hpp
@@ -78,8 +78,7 @@ class Signal_DSB : public Signal_Base
     void set_seed(int seed)
     {
       d_seed = seed;
-      if(d_seed < 0) d_seed = time(NULL);
-//      srand(d_seed);
+      if(d_seed < 0) d_seed = d_rd();
     }
 
 };

--- a/lib/signal_dsbsc.hpp
+++ b/lib/signal_dsbsc.hpp
@@ -78,8 +78,7 @@ class Signal_DSBSC : public Signal_Base
     void set_seed(int seed)
     {
       d_seed = seed;
-      if(d_seed < 0) d_seed = time(NULL);
-//      srand(d_seed);
+      if(d_seed < 0) d_seed = d_rd();
     }
 
 };

--- a/lib/signal_fm.hpp
+++ b/lib/signal_fm.hpp
@@ -74,8 +74,7 @@ class Signal_FM : public Signal_Base
     void set_seed(int seed)
     {
       d_seed = seed;
-      if(d_seed < 0) d_seed = time(NULL);
-//      srand(d_seed);
+      if(d_seed < 0) d_seed = d_rd();
     }
 
 };

--- a/lib/signal_lsb.hpp
+++ b/lib/signal_lsb.hpp
@@ -78,8 +78,7 @@ class Signal_LSB : public Signal_Base
     void set_seed(int seed)
     {
       d_seed = seed;
-      if(d_seed < 0) d_seed = time(NULL);
-//      srand(d_seed);
+      if(d_seed < 0) d_seed = d_rd();
     }
 
 };

--- a/lib/signal_pam.hpp
+++ b/lib/signal_pam.hpp
@@ -74,8 +74,7 @@ class Signal_PAM : public Signal_Base
     void set_seed(int seed)
     {
       d_seed = seed;
-      if(d_seed < 0) d_seed = time(NULL);
-//      srand(d_seed);
+      if(d_seed < 0) d_seed = d_rd();
     }
 
 };

--- a/lib/signal_psk.hpp
+++ b/lib/signal_psk.hpp
@@ -74,8 +74,7 @@ class Signal_PSK : public Signal_Base
     void set_seed(int seed)
     {
       d_seed = seed;
-      if(d_seed < 0) d_seed = time(NULL);
-//      srand(d_seed);
+      if(d_seed < 0) d_seed = d_rd();
     }
 
 };

--- a/lib/signal_qam.hpp
+++ b/lib/signal_qam.hpp
@@ -74,8 +74,7 @@ class Signal_QAM : public Signal_Base
     void set_seed(int seed)
     {
       d_seed = seed;
-      if(d_seed < 0) d_seed = time(NULL);
-//      srand(d_seed);
+      if(d_seed < 0) d_seed = d_rd();
     }
 
 };

--- a/lib/signal_usb.hpp
+++ b/lib/signal_usb.hpp
@@ -78,8 +78,7 @@ class Signal_USB : public Signal_Base
     void set_seed(int seed)
     {
       d_seed = seed;
-      if(d_seed < 0) d_seed = time(NULL);
-//      srand(d_seed);
+      if(d_seed < 0) d_seed = d_rd();
     }
 
 };


### PR DESCRIPTION
Augmented the random seed generation with boost::random_device to 'hopefully' prevent two blocks from using the same exact sequence. This requires that the libboost-random1.xx-dev library be findable by cmake.

OFDM overhaul, fixed some filter slippage points, seems to be working reasonably now.