### PR TITLE
forget to include the stdio header, was apparently included somewhere…

### DIFF
--- a/lib/periodic_gate_impl.cc
+++ b/lib/periodic_gate_impl.cc
@@ -24,6 +24,7 @@
 
 #include <gnuradio/io_signature.h>
 #include "periodic_gate_impl.h"
+#include <stdio.h>
 
 namespace gr {
   namespace signal_exciter {

--- a/lib/random_gate_impl.cc
+++ b/lib/random_gate_impl.cc
@@ -24,6 +24,7 @@
 
 #include <gnuradio/io_signature.h>
 #include "random_gate_impl.h"
+#include <stdio.h>
 
 namespace gr {
   namespace signal_exciter {


### PR DESCRIPTION
… up-chain and is no longer present.

added in <stdio.h> that was needed for compile.